### PR TITLE
🚀 feat(backend): add support for enums endpoint

### DIFF
--- a/backend/src/main/java/com/dresscode/constants/ApiRoutes.java
+++ b/backend/src/main/java/com/dresscode/constants/ApiRoutes.java
@@ -9,5 +9,6 @@ public class ApiRoutes {
     public static final String AUTH = API_BASE + "/auth";
     public static final String EVENTS = API_BASE + "/events";
     public static final String IMAGES = API_BASE + "/images";
+    public static final String ENUMS = API_BASE + "/enums";
 
 }

--- a/backend/src/main/java/com/dresscode/controller/EnumController.java
+++ b/backend/src/main/java/com/dresscode/controller/EnumController.java
@@ -1,0 +1,28 @@
+package com.dresscode.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.dresscode.constants.ApiRoutes;
+import com.dresscode.dto.enums.ClothingItemEnumsDto;
+import com.dresscode.service.EnumService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(ApiRoutes.ENUMS)
+public class EnumController {
+    private final EnumService enumService;
+
+    @GetMapping()
+    @Operation(summary = "Get all clothing item enums")
+    public ResponseEntity<ClothingItemEnumsDto> getAllClothingItemEnums() {
+        return ResponseEntity.ok(enumService.getAllClothingItemEnums());
+    }
+
+}

--- a/backend/src/main/java/com/dresscode/dto/enums/ClothingItemEnumsDto.java
+++ b/backend/src/main/java/com/dresscode/dto/enums/ClothingItemEnumsDto.java
@@ -1,0 +1,15 @@
+package com.dresscode.dto.enums;
+
+import java.util.List;
+
+import lombok.Data;
+
+@Data
+public class ClothingItemEnumsDto {
+
+    private List<String> availability;
+    private List<String> gender;
+    private List<String> size;
+    private List<String> state;
+    private List<String> type;
+}

--- a/backend/src/main/java/com/dresscode/security/SecurityConfig.java
+++ b/backend/src/main/java/com/dresscode/security/SecurityConfig.java
@@ -59,6 +59,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.GET, "api/events/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.GET, "api/clothing-items/**").hasRole("ADMIN")
                 .requestMatchers(HttpMethod.GET, "api/clothing-items/available").authenticated()
+                .requestMatchers(HttpMethod.GET, "api/enums").authenticated()
 
                 // .requestMatchers(HttpMethod.GET, "/api/clases/**").hasAnyRole("STUDENT",
                 // "TEACHER", "ADMIN")

--- a/backend/src/main/java/com/dresscode/service/EnumService.java
+++ b/backend/src/main/java/com/dresscode/service/EnumService.java
@@ -1,0 +1,9 @@
+package com.dresscode.service;
+
+import com.dresscode.dto.enums.ClothingItemEnumsDto;
+
+public interface EnumService {
+
+    ClothingItemEnumsDto getAllClothingItemEnums();
+
+}

--- a/backend/src/main/java/com/dresscode/service/impl/EnumServiceImpl.java
+++ b/backend/src/main/java/com/dresscode/service/impl/EnumServiceImpl.java
@@ -1,0 +1,39 @@
+package com.dresscode.service.impl;
+
+import java.util.Arrays;
+
+import org.springframework.stereotype.Service;
+
+import com.dresscode.dto.enums.ClothingItemEnumsDto;
+import com.dresscode.enums.ClothingItemAvailabilityEnum;
+import com.dresscode.enums.ClothingItemGenderEnum;
+import com.dresscode.enums.ClothingItemSizeEnum;
+import com.dresscode.enums.ClothingItemStateEnum;
+import com.dresscode.enums.ClothingItemTypeEnum;
+import com.dresscode.service.EnumService;
+
+@Service
+public class EnumServiceImpl implements EnumService {
+
+        @Override
+        public ClothingItemEnumsDto getAllClothingItemEnums() {
+                ClothingItemEnumsDto dto = new ClothingItemEnumsDto();
+                dto.setAvailability(Arrays.stream(ClothingItemAvailabilityEnum.values())
+                                .map(Enum::name)
+                                .toList());
+                dto.setGender(Arrays.stream(ClothingItemGenderEnum.values())
+                                .map(Enum::name)
+                                .toList());
+                dto.setSize(Arrays.stream(ClothingItemSizeEnum.values())
+                                .map(Enum::name)
+                                .toList());
+                dto.setState(Arrays.stream(ClothingItemStateEnum.values())
+                                .map(Enum::name)
+                                .toList());
+                dto.setType(Arrays.stream(ClothingItemTypeEnum.values())
+                                .map(Enum::name)
+                                .toList());
+                return dto;
+        }
+
+}


### PR DESCRIPTION
# ✨ Add support for enums endpoint

## Description

This PR introduces a new backend endpoint to expose all relevant enum values related to clothing items.  
The endpoint aggregates enums such as availability, gender, size, state, and type into a single DTO for easy consumption by the frontend.

## Changes
- Added `EnumController` with a `GET /api/enums` endpoint
- Created `ClothingItemEnumsDto` to encapsulate all enum values
- Delegated enum retrieval logic to `EnumService`
- Returned enums as lists of strings for easy frontend integration
